### PR TITLE
feat: add ticket hook support and path-based triggering

### DIFF
--- a/src/lib/__tests__/hookGenerator.test.ts
+++ b/src/lib/__tests__/hookGenerator.test.ts
@@ -1,0 +1,198 @@
+import { HookGenerator } from "../hookGenerator";
+import * as fs from "fs/promises";
+import * as path from "path";
+
+jest.mock("fs/promises");
+jest.mock("../logger", () => ({
+  logger: {
+    info: jest.fn(),
+    success: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe("HookGenerator", () => {
+  let hookGenerator: HookGenerator;
+  const mockProjectRoot = "/test/project";
+  
+  beforeEach(() => {
+    jest.clearAllMocks();
+    hookGenerator = new HookGenerator(mockProjectRoot);
+  });
+
+  describe("generate", () => {
+    beforeEach(() => {
+      (fs.mkdir as jest.Mock).mockResolvedValue(undefined);
+      (fs.writeFile as jest.Mock).mockResolvedValue(undefined);
+      (fs.readFile as jest.Mock).mockRejectedValue(new Error("File not found"));
+    });
+
+    it("should create required directories", async () => {
+      await hookGenerator.generate();
+
+      expect(fs.mkdir).toHaveBeenCalledWith(
+        path.join(mockProjectRoot, ".claude"),
+        { recursive: true }
+      );
+      expect(fs.mkdir).toHaveBeenCalledWith(
+        path.join(mockProjectRoot, ".memento/hooks"),
+        { recursive: true }
+      );
+    });
+
+    it("should generate routing script with correct content", async () => {
+      await hookGenerator.generate();
+
+      const scriptPath = path.join(mockProjectRoot, ".memento/hooks/routing.sh");
+      const writeCall = (fs.writeFile as jest.Mock).mock.calls.find(
+        (call) => call[0] === scriptPath
+      );
+
+      expect(writeCall).toBeDefined();
+      
+      const scriptContent = writeCall[1];
+      
+      // Check for mode, workflow, and ticket extraction
+      expect(scriptContent).toContain("MODE_REQUEST=");
+      expect(scriptContent).toContain("WORKFLOW_REQUEST=");
+      expect(scriptContent).toContain("TICKET_REQUEST=");
+      
+      // Check for path-based detection
+      expect(scriptContent).toContain("MEMENTO_MODE_PATH=");
+      expect(scriptContent).toContain("MEMENTO_WORKFLOW_PATH=");
+      expect(scriptContent).toContain("MEMENTO_TICKET_PATH=");
+      
+      // Check for ticket processing logic
+      expect(scriptContent).toContain("find_ticket()");
+      expect(scriptContent).toContain("## Ticket:");
+      
+      // Check injection order (mode, workflow, ticket, then user prompt)
+      const modeIndex = scriptContent.indexOf("Process mode request");
+      const workflowIndex = scriptContent.indexOf("Process workflow request");
+      const ticketIndex = scriptContent.indexOf("Process ticket request");
+      const promptIndex = scriptContent.indexOf("# Output the original prompt");
+      
+      expect(modeIndex).toBeLessThan(workflowIndex);
+      expect(workflowIndex).toBeLessThan(ticketIndex);
+      expect(ticketIndex).toBeLessThan(promptIndex);
+      
+      // Check file permissions
+      expect(writeCall[2]).toEqual({ mode: 0o755 });
+    });
+
+    it("should handle ticket: prefix extraction correctly", async () => {
+      await hookGenerator.generate();
+
+      const scriptContent = (fs.writeFile as jest.Mock).mock.calls.find(
+        (call) => call[0].includes("routing.sh")
+      )[1];
+
+      // Check regex patterns for ticket extraction
+      expect(scriptContent).toMatch(/\[Tt\]icket:\[.*\]\*\[A-Za-z0-9_\/-\]\*/);
+    });
+
+    it("should handle .memento path extraction correctly", async () => {
+      await hookGenerator.generate();
+
+      const scriptContent = (fs.writeFile as jest.Mock).mock.calls.find(
+        (call) => call[0].includes("routing.sh")
+      )[1];
+
+      // Check path extraction patterns
+      expect(scriptContent).toContain("\\.memento/modes/");
+      expect(scriptContent).toContain("\\.memento/workflows/");
+      expect(scriptContent).toContain("\\.memento/tickets/");
+    });
+
+    it("should create settings.toml with hook configuration", async () => {
+      await hookGenerator.generate();
+
+      const settingsPath = path.join(mockProjectRoot, ".claude/settings.toml");
+      const writeCall = (fs.writeFile as jest.Mock).mock.calls.find(
+        (call) => call[0] === settingsPath
+      );
+
+      expect(writeCall).toBeDefined();
+      
+      const settingsContent = writeCall[1];
+      expect(settingsContent).toContain("[[hooks]]");
+      expect(settingsContent).toContain('event = "UserPromptSubmit"');
+      expect(settingsContent).toContain('command = "./.memento/hooks/routing.sh"');
+    });
+
+    it("should not duplicate hook in existing settings.toml", async () => {
+      const existingSettings = `
+[[hooks]]
+event = "UserPromptSubmit"
+command = "./.memento/hooks/routing.sh"
+`;
+      (fs.readFile as jest.Mock).mockResolvedValueOnce(existingSettings);
+
+      await hookGenerator.generate();
+
+      expect(fs.writeFile).not.toHaveBeenCalledWith(
+        expect.stringContaining("settings.toml"),
+        expect.any(String)
+      );
+    });
+
+    it("should append hook to existing settings.toml", async () => {
+      const existingSettings = `
+[some_other_config]
+value = "test"
+`;
+      (fs.readFile as jest.Mock).mockResolvedValueOnce(existingSettings);
+
+      await hookGenerator.generate();
+
+      const settingsPath = path.join(mockProjectRoot, ".claude/settings.toml");
+      const writeCall = (fs.writeFile as jest.Mock).mock.calls.find(
+        (call) => call[0] === settingsPath
+      );
+
+      expect(writeCall).toBeDefined();
+      
+      const settingsContent = writeCall[1];
+      expect(settingsContent).toContain(existingSettings.trim());
+      expect(settingsContent).toContain("[[hooks]]");
+      expect(settingsContent).toContain('command = "./.memento/hooks/routing.sh"');
+    });
+  });
+
+  describe("routing script ticket functionality", () => {
+    let scriptContent: string;
+
+    beforeEach(async () => {
+      (fs.mkdir as jest.Mock).mockResolvedValue(undefined);
+      (fs.writeFile as jest.Mock).mockResolvedValue(undefined);
+      (fs.readFile as jest.Mock).mockRejectedValue(new Error("File not found"));
+      
+      await hookGenerator.generate();
+      
+      scriptContent = (fs.writeFile as jest.Mock).mock.calls.find(
+        (call) => call[0].includes("routing.sh")
+      )[1];
+    });
+
+    it("should handle ticket paths with status prefix", () => {
+      // Check that the script handles paths like "done/ticket-name"
+      expect(scriptContent).toContain('echo "$ticket" | grep -q "^$status/"');
+    });
+
+    it("should search across all ticket status directories", () => {
+      expect(scriptContent).toContain('statuses=("next" "in-progress" "done")');
+    });
+
+    it("should output ticket metadata and content files", () => {
+      expect(scriptContent).toContain("metadata.json");
+      expect(scriptContent).toContain("progress.md");
+      expect(scriptContent).toContain("decisions.md");
+    });
+
+    it("should list available tickets when not found", () => {
+      expect(scriptContent).toContain("Available tickets:");
+      expect(scriptContent).toContain('for status in next in-progress done');
+    });
+  });
+});

--- a/src/lib/hookGenerator.ts
+++ b/src/lib/hookGenerator.ts
@@ -48,9 +48,26 @@ export class HookGenerator {
 # Get user prompt from stdin
 PROMPT=$(cat)
 
-# Extract mode/workflow request
+# Extract mode/workflow/ticket request
 MODE_REQUEST=$(echo "$PROMPT" | grep -o '[Mm]ode:[[:space:]]*[A-Za-z0-9_-]*' | sed 's/[Mm]ode:[[:space:]]*//' || true)
 WORKFLOW_REQUEST=$(echo "$PROMPT" | grep -o '[Ww]orkflow:[[:space:]]*[A-Za-z0-9_-]*' | sed 's/[Ww]orkflow:[[:space:]]*//' || true)
+TICKET_REQUEST=$(echo "$PROMPT" | grep -o '[Tt]icket:[[:space:]]*[A-Za-z0-9_/-]*' | sed 's/[Tt]icket:[[:space:]]*//' || true)
+
+# Extract .memento paths from prompt
+MEMENTO_MODE_PATH=$(echo "$PROMPT" | grep -o '\\.memento/modes/[A-Za-z0-9_-]*\\.md' | sed 's|\\.memento/modes/||; s|\\.md||' | head -1 || true)
+MEMENTO_WORKFLOW_PATH=$(echo "$PROMPT" | grep -o '\\.memento/workflows/[A-Za-z0-9_-]*\\.md' | sed 's|\\.memento/workflows/||; s|\\.md||' | head -1 || true)
+MEMENTO_TICKET_PATH=$(echo "$PROMPT" | grep -o '\\.memento/tickets/[A-Za-z0-9_/-]*' | sed 's|\\.memento/tickets/||' | head -1 || true)
+
+# Use path-based detection if no explicit request
+if [ -z "$MODE_REQUEST" ] && [ -n "$MEMENTO_MODE_PATH" ]; then
+    MODE_REQUEST="$MEMENTO_MODE_PATH"
+fi
+if [ -z "$WORKFLOW_REQUEST" ] && [ -n "$MEMENTO_WORKFLOW_PATH" ]; then
+    WORKFLOW_REQUEST="$MEMENTO_WORKFLOW_PATH"
+fi
+if [ -z "$TICKET_REQUEST" ] && [ -n "$MEMENTO_TICKET_PATH" ]; then
+    TICKET_REQUEST="$MEMENTO_TICKET_PATH"
+fi
 
 # Read default mode from config if no mode specified
 DEFAULT_MODE=""
@@ -212,6 +229,82 @@ if [ -n "$WORKFLOW_REQUEST" ]; then
         done
         echo ""
         echo "Claude will select the most appropriate workflow based on context."
+    fi
+    echo ""
+fi
+
+# Process ticket request
+if [ -n "$TICKET_REQUEST" ]; then
+    # Function to find ticket in any status directory
+    find_ticket() {
+        local ticket="$1"
+        local statuses=("next" "in-progress" "done")
+        
+        for status in "\${statuses[@]}"; do
+            # Check if ticket is already a path with status
+            if echo "$ticket" | grep -q "^$status/"; then
+                if [ -d ".memento/tickets/$ticket" ]; then
+                    echo "$ticket"
+                    return
+                fi
+            else
+                # Search in each status directory
+                if [ -d ".memento/tickets/$status/$ticket" ]; then
+                    echo "$status/$ticket"
+                    return
+                fi
+            fi
+        done
+        
+        echo ""
+    }
+    
+    TICKET_PATH=$(find_ticket "$TICKET_REQUEST")
+    
+    if [ -z "$TICKET_PATH" ]; then
+        echo "## No Ticket Match Found"
+        echo "Could not find a ticket matching: $TICKET_REQUEST"
+        echo "Available tickets:"
+        for status in next in-progress done; do
+            if [ -d ".memento/tickets/$status" ]; then
+                echo "  $status:"
+                ls ".memento/tickets/$status" 2>/dev/null | sed 's/^/    - /' || true
+            fi
+        done
+    else
+        echo "## Ticket: $TICKET_PATH"
+        
+        # Output metadata if exists
+        if [ -f ".memento/tickets/$TICKET_PATH/metadata.json" ]; then
+            echo "### Metadata"
+            cat ".memento/tickets/$TICKET_PATH/metadata.json"
+            echo ""
+        fi
+        
+        # Output progress if exists
+        if [ -f ".memento/tickets/$TICKET_PATH/progress.md" ]; then
+            echo "### Progress"
+            cat ".memento/tickets/$TICKET_PATH/progress.md"
+            echo ""
+        fi
+        
+        # Output decisions if exists
+        if [ -f ".memento/tickets/$TICKET_PATH/decisions.md" ]; then
+            echo "### Decisions"
+            cat ".memento/tickets/$TICKET_PATH/decisions.md"
+            echo ""
+        fi
+        
+        # Output any other markdown files in the ticket directory
+        if [ -d ".memento/tickets/$TICKET_PATH" ]; then
+            for file in ".memento/tickets/$TICKET_PATH"/*.md; do
+                if [ -f "$file" ] && [ "$(basename "$file")" != "progress.md" ] && [ "$(basename "$file")" != "decisions.md" ]; then
+                    echo "### $(basename "$file" .md)"
+                    cat "$file"
+                    echo ""
+                fi
+            done
+        fi
     fi
     echo ""
 fi


### PR DESCRIPTION
- Add support for `ticket:` prefix to inject ticket context
- Add path-based triggering for .memento/* file paths
- Support searching tickets across all status directories
- Maintain injection order: mode, workflow, ticket, user prompt
- Add comprehensive unit tests for hook functionality

🤖 Generated with [Claude Code](https://claude.ai/code)