### PR TITLE
feat: add session tracking support for tickets

### DIFF
--- a/src/commands/ticket.ts
+++ b/src/commands/ticket.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import { TicketManager, TicketStatus } from '../lib/ticketManager';
 import { logger } from '../lib/logger';
+import { SessionRecorder } from '../lib/sessionRecorder';
 
 const ticketCommand = new Command('ticket')
   .description('Manage tickets for persistent workspace');
@@ -95,6 +96,29 @@ ticketCommand
       logger.success(`Deleted ticket: ${name}`);
     } catch (error) {
       logger.error(`Failed to delete ticket: ${error}`);
+      process.exit(1);
+    }
+  });
+
+// Record subcommand
+ticketCommand
+  .command('record [name]')
+  .description('Record current session context to a ticket')
+  .option('-s, --summary <summary>', 'Custom session summary')
+  .action(async (name?: string, options?: { summary?: string }) => {
+    try {
+      const sessionRecorder = new SessionRecorder(process.cwd());
+      const ticketName = await sessionRecorder.recordSession(name, options?.summary);
+      
+      if (name && name === ticketName) {
+        logger.success(`Recorded session to existing ticket: ${ticketName}`);
+      } else {
+        logger.success(`Recorded session to ticket: ${ticketName}`);
+      }
+      
+      logger.info(`Session context has been ${name ? 'appended to' : 'saved in'} ticket '${ticketName}'`);
+    } catch (error) {
+      logger.error(`Failed to record session: ${error}`);
       process.exit(1);
     }
   });

--- a/src/lib/__tests__/sessionRecorder.test.ts
+++ b/src/lib/__tests__/sessionRecorder.test.ts
@@ -1,0 +1,115 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { SessionRecorder } from '../sessionRecorder';
+import { TicketManager } from '../ticketManager';
+
+// Mock the file system and TicketManager
+jest.mock('fs');
+jest.mock('../ticketManager');
+
+const mockedFs = fs as jest.Mocked<typeof fs>;
+const MockedTicketManager = TicketManager as jest.MockedClass<typeof TicketManager>;
+
+describe('SessionRecorder', () => {
+  let sessionRecorder: SessionRecorder;
+  let mockTicketManager: jest.Mocked<TicketManager>;
+  const testProjectRoot = '/test/project';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // Setup mocked TicketManager
+    mockTicketManager = {
+      list: jest.fn(),
+    } as any;
+    MockedTicketManager.mockImplementation(() => mockTicketManager);
+    
+    sessionRecorder = new SessionRecorder(testProjectRoot);
+
+    // Mock fs.existsSync to return false by default
+    mockedFs.existsSync.mockReturnValue(false);
+    mockedFs.mkdirSync.mockReturnValue(undefined);
+    mockedFs.writeFileSync.mockReturnValue(undefined);
+    mockedFs.readFileSync.mockReturnValue('');
+    mockedFs.readdirSync.mockReturnValue([]);
+  });
+
+  describe('recordSession', () => {
+    it('should create a new ticket when no existing ticket found', async () => {
+      // Mock no tickets found
+      mockTicketManager.list.mockResolvedValue([]);
+
+      const result = await sessionRecorder.recordSession();
+
+      expect(result).toMatch(/^session-\d+$/);
+      expect(mockedFs.writeFileSync).toHaveBeenCalled();
+    });
+
+    it('should append to existing ticket when specified', async () => {
+      const ticketName = 'existing-ticket';
+      
+      // Mock existing ticket
+      mockTicketManager.list.mockResolvedValue([
+        { name: ticketName, status: 'in-progress' }
+      ]);
+      
+      // Mock existing ticket file
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readFileSync.mockReturnValue('# Existing Ticket\n\nSome content');
+
+      const result = await sessionRecorder.recordSession(ticketName);
+
+      expect(result).toBe(ticketName);
+      expect(mockedFs.readFileSync).toHaveBeenCalled();
+      expect(mockedFs.writeFileSync).toHaveBeenCalled();
+    });
+
+    it('should find relevant in-progress ticket when none specified', async () => {
+      const ticketName = 'auto-found-ticket';
+      
+      // Mock one in-progress ticket
+      mockTicketManager.list.mockResolvedValue([
+        { name: ticketName, status: 'in-progress' },
+        { name: 'done-ticket', status: 'done' }
+      ]);
+      
+      // Mock existing ticket file
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readFileSync.mockReturnValue('# Auto Found Ticket');
+
+      const result = await sessionRecorder.recordSession();
+
+      expect(result).toBe(ticketName);
+    });
+
+    it('should use custom summary when provided', async () => {
+      const customSummary = 'Custom session summary';
+      mockTicketManager.list.mockResolvedValue([]);
+
+      await sessionRecorder.recordSession(undefined, customSummary);
+
+      // Verify that writeFileSync was called with content containing the custom summary
+      const writeCall = mockedFs.writeFileSync.mock.calls[0];
+      expect(writeCall[1]).toContain(customSummary);
+    });
+  });
+
+  describe('session context capture', () => {
+    it('should capture basic session context', async () => {
+      mockTicketManager.list.mockResolvedValue([]);
+      
+      // Mock git directory exists
+      mockedFs.existsSync.mockImplementation((path: any) => {
+        return path.toString().endsWith('.git');
+      });
+
+      await sessionRecorder.recordSession();
+
+      const writeCall = mockedFs.writeFileSync.mock.calls[0];
+      const content = writeCall[1] as string;
+      
+      expect(content).toContain('Working Directory:');
+      expect(content).toContain('Git Repository: Yes');
+    });
+  });
+});

--- a/src/lib/sessionRecorder.ts
+++ b/src/lib/sessionRecorder.ts
@@ -1,0 +1,255 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { TicketManager } from './ticketManager';
+
+export interface SessionEntry {
+  timestamp: string;
+  summary: string;
+  context?: string;
+  sessionId?: string;
+}
+
+export class SessionRecorder {
+  private ticketManager: TicketManager;
+  private projectRoot: string;
+
+  constructor(projectRoot: string) {
+    this.projectRoot = projectRoot;
+    this.ticketManager = new TicketManager(projectRoot);
+  }
+
+  /**
+   * Generate a simple session ID based on current timestamp
+   */
+  private generateSessionId(): string {
+    return `session-${Date.now()}`;
+  }
+
+  /**
+   * Capture basic session context
+   */
+  private captureSessionContext(): string {
+    const context = [];
+    
+    // Current working directory
+    context.push(`Working Directory: ${this.projectRoot}`);
+    
+    // Git status if available
+    try {
+      const gitDir = path.join(this.projectRoot, '.git');
+      if (fs.existsSync(gitDir)) {
+        context.push('Git Repository: Yes');
+        // Could add more git context here if needed
+      }
+    } catch (error) {
+      // Ignore git errors
+    }
+
+    // Recent file modifications (simple approach)
+    try {
+      const recentFiles = this.getRecentlyModifiedFiles();
+      if (recentFiles.length > 0) {
+        context.push(`Recently Modified Files: ${recentFiles.slice(0, 5).join(', ')}`);
+      }
+    } catch (error) {
+      // Ignore file system errors
+    }
+
+    return context.join('\n');
+  }
+
+  /**
+   * Get recently modified files (within last hour)
+   */
+  private getRecentlyModifiedFiles(): string[] {
+    const recentFiles: string[] = [];
+    const oneHourAgo = Date.now() - (60 * 60 * 1000);
+
+    const scanDirectory = (dir: string, depth = 0) => {
+      if (depth > 2) return; // Limit depth to avoid performance issues
+
+      try {
+        const entries = fs.readdirSync(dir, { withFileTypes: true });
+        
+        for (const entry of entries) {
+          const fullPath = path.join(dir, entry.name);
+          
+          // Skip hidden directories and node_modules
+          if (entry.name.startsWith('.') || entry.name === 'node_modules') {
+            continue;
+          }
+
+          if (entry.isFile()) {
+            const stats = fs.statSync(fullPath);
+            if (stats.mtime.getTime() > oneHourAgo) {
+              recentFiles.push(path.relative(this.projectRoot, fullPath));
+            }
+          } else if (entry.isDirectory()) {
+            scanDirectory(fullPath, depth + 1);
+          }
+        }
+      } catch (error) {
+        // Ignore directory scan errors
+      }
+    };
+
+    scanDirectory(this.projectRoot);
+    return recentFiles;
+  }
+
+  /**
+   * Generate a session summary (simplified version - in real implementation could use AI)
+   */
+  private generateSessionSummary(ticketName?: string): string {
+    const recentFiles = this.getRecentlyModifiedFiles();
+    const timestamp = new Date().toLocaleString();
+    
+    let summary = `Session recorded at ${timestamp}`;
+    
+    if (ticketName) {
+      summary += ` for ticket: ${ticketName}`;
+    }
+
+    if (recentFiles.length > 0) {
+      summary += `\n\nRecent activity:`;
+      summary += `\n- Modified ${recentFiles.length} file(s)`;
+      summary += `\n- Key files: ${recentFiles.slice(0, 3).join(', ')}`;
+    }
+
+    // Add placeholder for AI-generated summary
+    summary += `\n\n*Note: In a full implementation, this would include an AI-generated summary of the session using Haiku or similar model.*`;
+
+    return summary;
+  }
+
+  /**
+   * Find the most relevant ticket for current session
+   */
+  private async findRelevantTicket(): Promise<string | null> {
+    const tickets = await this.ticketManager.list();
+    
+    // Simple heuristic: find tickets in 'in-progress' status first
+    const inProgressTickets = tickets.filter(t => t.status === 'in-progress');
+    if (inProgressTickets.length === 1) {
+      return inProgressTickets[0].name;
+    }
+
+    // If multiple or no in-progress tickets, return null to create new one
+    return null;
+  }
+
+  /**
+   * Record current session to a ticket
+   */
+  async recordSession(ticketName?: string, summary?: string): Promise<string> {
+    let targetTicket = ticketName;
+    
+    // If no ticket specified, try to find relevant one
+    if (!targetTicket) {
+      targetTicket = await this.findRelevantTicket();
+    }
+
+    // Generate session summary
+    const sessionSummary = summary || this.generateSessionSummary(targetTicket);
+    const sessionContext = this.captureSessionContext();
+    const sessionId = this.generateSessionId();
+
+    const sessionEntry: SessionEntry = {
+      timestamp: new Date().toISOString(),
+      summary: sessionSummary,
+      context: sessionContext,
+      sessionId
+    };
+
+    // If we have a target ticket, append to it
+    if (targetTicket) {
+      await this.appendToTicket(targetTicket, sessionEntry);
+      return targetTicket;
+    } else {
+      // Create new ticket
+      const newTicketName = `session-${Date.now()}`;
+      await this.createTicketWithSession(newTicketName, sessionEntry);
+      return newTicketName;
+    }
+  }
+
+  /**
+   * Append session entry to existing ticket
+   */
+  private async appendToTicket(ticketName: string, sessionEntry: SessionEntry): Promise<void> {
+    const tickets = await this.ticketManager.list();
+    const ticket = tickets.find(t => t.name === ticketName);
+    
+    if (!ticket) {
+      throw new Error(`Ticket '${ticketName}' not found`);
+    }
+
+    // Read current ticket content
+    const ticketPath = path.join(this.projectRoot, '.memento', 'tickets', ticket.status, `${ticketName}.md`);
+    let content = '';
+    
+    if (fs.existsSync(ticketPath)) {
+      content = fs.readFileSync(ticketPath, 'utf8');
+    }
+
+    // Append session entry
+    const sessionSection = `
+
+---
+
+## Session Entry - ${new Date(sessionEntry.timestamp).toLocaleString()}
+**Session ID:** ${sessionEntry.sessionId}
+
+### Summary
+${sessionEntry.summary}
+
+### Context
+\`\`\`
+${sessionEntry.context}
+\`\`\`
+`;
+
+    content += sessionSection;
+    fs.writeFileSync(ticketPath, content);
+  }
+
+  /**
+   * Create new ticket with session entry
+   */
+  private async createTicketWithSession(ticketName: string, sessionEntry: SessionEntry): Promise<void> {
+    // Create basic ticket structure with session
+    const content = `# ${ticketName}
+
+## Description
+Session-based ticket created automatically.
+
+## Tasks
+- [ ] Review session context
+- [ ] Define specific tasks
+
+## Session Entry - ${new Date(sessionEntry.timestamp).toLocaleString()}
+**Session ID:** ${sessionEntry.sessionId}
+
+### Summary
+${sessionEntry.summary}
+
+### Context
+\`\`\`
+${sessionEntry.context}
+\`\`\`
+
+---
+Created: ${sessionEntry.timestamp}
+`;
+
+    const ticketPath = path.join(this.projectRoot, '.memento', 'tickets', 'next', `${ticketName}.md`);
+    
+    // Ensure directory exists
+    const ticketDir = path.dirname(ticketPath);
+    if (!fs.existsSync(ticketDir)) {
+      fs.mkdirSync(ticketDir, { recursive: true });
+    }
+    
+    fs.writeFileSync(ticketPath, content);
+  }
+}


### PR DESCRIPTION
Add session tracking support for tickets as requested in issue #9.

This implements a `record` subcommand that:
- Captures current session context (files, git status, etc.)
- Automatically detects relevant tickets or creates new ones
- Stores session metadata and summaries in ticket files
- Enables persistent context across Claude Code sessions

Addresses ##9

Generated with [Claude Code](https://claude.ai/code)