### PR TITLE
feat: encourage Claude to read tickets directly in project overview hook

### DIFF
--- a/.memento/hooks/scripts/project-overview.sh
+++ b/.memento/hooks/scripts/project-overview.sh
@@ -14,9 +14,14 @@ echo '#### In Progress'
 if [ -d ".memento/tickets/in-progress" ]; then
     tickets=$(find .memento/tickets/in-progress -name '*.md' 2>/dev/null)
     if [ -n "$tickets" ]; then
+        echo "The following tickets are currently in progress. **You should read these ticket files directly** to understand the current context and continue working on them:"
+        echo
         echo "$tickets" | while read -r ticket; do
-            echo "- $(basename "$ticket" .md)"
+            ticket_name="$(basename "$ticket" .md)"
+            echo "- **$ticket_name** - Read the full ticket: \`$ticket\`"
         done
+        echo
+        echo "Use the Read tool to examine ticket content directly, as there are no ticket commands to read ticket content automatically."
     else
         echo "No tickets in progress"
     fi
@@ -28,8 +33,18 @@ echo
 # Next Tickets
 echo '#### Next'
 if [ -d ".memento/tickets/next" ]; then
-    count=$(find .memento/tickets/next -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
-    echo "$count tickets"
+    tickets=$(find .memento/tickets/next -name '*.md' 2>/dev/null)
+    if [ -n "$tickets" ]; then
+        count=$(echo "$tickets" | wc -l | tr -d ' ')
+        echo "$count tickets ready to start. **Consider reading these tickets** to understand upcoming work:"
+        echo
+        echo "$tickets" | while read -r ticket; do
+            ticket_name="$(basename "$ticket" .md)"
+            echo "- **$ticket_name** - Read the ticket: \`$ticket\`"
+        done
+    else
+        echo "0 tickets"
+    fi
 else
     echo "0 tickets"
 fi
@@ -39,7 +54,7 @@ echo
 echo '#### Done'
 if [ -d ".memento/tickets/done" ]; then
     count=$(find .memento/tickets/done -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
-    echo "$count tickets"
+    echo "$count tickets completed"
 else
     echo "0 tickets"
 fi

--- a/templates/hooks/project-overview.sh
+++ b/templates/hooks/project-overview.sh
@@ -14,9 +14,14 @@ echo '#### In Progress'
 if [ -d ".memento/tickets/in-progress" ]; then
     tickets=$(find .memento/tickets/in-progress -name '*.md' 2>/dev/null)
     if [ -n "$tickets" ]; then
+        echo "The following tickets are currently in progress. **You should read these ticket files directly** to understand the current context and continue working on them:"
+        echo
         echo "$tickets" | while read -r ticket; do
-            echo "- $(basename "$ticket" .md)"
+            ticket_name="$(basename "$ticket" .md)"
+            echo "- **$ticket_name** - Read the full ticket: \`$ticket\`"
         done
+        echo
+        echo "Use the Read tool to examine ticket content directly, as there are no ticket commands to read ticket content automatically."
     else
         echo "No tickets in progress"
     fi
@@ -28,8 +33,18 @@ echo
 # Next Tickets
 echo '#### Next'
 if [ -d ".memento/tickets/next" ]; then
-    count=$(find .memento/tickets/next -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
-    echo "$count tickets"
+    tickets=$(find .memento/tickets/next -name '*.md' 2>/dev/null)
+    if [ -n "$tickets" ]; then
+        count=$(echo "$tickets" | wc -l | tr -d ' ')
+        echo "$count tickets ready to start. **Consider reading these tickets** to understand upcoming work:"
+        echo
+        echo "$tickets" | while read -r ticket; do
+            ticket_name="$(basename "$ticket" .md)"
+            echo "- **$ticket_name** - Read the ticket: \`$ticket\`"
+        done
+    else
+        echo "0 tickets"
+    fi
 else
     echo "0 tickets"
 fi
@@ -39,7 +54,7 @@ echo
 echo '#### Done'
 if [ -d ".memento/tickets/done" ]; then
     count=$(find .memento/tickets/done -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
-    echo "$count tickets"
+    echo "$count tickets completed"
 else
     echo "0 tickets"
 fi


### PR DESCRIPTION
Enhanced the project-overview.sh hook to encourage Claude to read ticket files directly.

## Changes
- Show full ticket file paths instead of just names
- Added explicit instructions to use Read tool for ticket content
- Explained there are no ticket commands to read content automatically
- Enhanced guidance for both in-progress and next tickets
- Updated both template and installed versions

Fixes #13

Generated with [Claude Code](https://claude.ai/code)