### PR TITLE
feat: encourage Claude to read tickets directly in memento-routing hook

### DIFF
--- a/.memento/hooks/scripts/memento-routing.sh
+++ b/.memento/hooks/scripts/memento-routing.sh
@@ -260,9 +260,11 @@ if [ -n "$TICKET_REQUEST" ]; then
         echo "### Working with Tickets"
         echo ""
         echo "- Tickets are simple markdown files that serve as persistent workspaces"
+        echo "- **Read ticket files directly using the Read tool to understand their content**"
         echo "- Use your file editing tools to update ticket content directly"
         echo "- Tickets survive between sessions - use them to track progress and share context"
         echo "- When working on large tasks, create multiple tickets and delegate to sub-agents"
+        echo "- **Note: There are no built-in ticket commands to read content - use Read tool for file paths shown above**"
         echo ""
         
         # Output ticket content
@@ -305,9 +307,11 @@ if [ -z "$TICKET_REQUEST" ]; then
         echo "### Working with Tickets"
         echo ""
         echo "- Tickets are simple markdown files that serve as persistent workspaces"
+        echo "- **Read ticket files directly using the Read tool to understand their content**"
         echo "- Use your file editing tools to update ticket content directly"
         echo "- Tickets survive between sessions - use them to track progress and share context"
         echo "- When working on large tasks, create multiple tickets and delegate to sub-agents"
+        echo "- **Note: There are no built-in ticket commands to read content - use Read tool for file paths shown above**"
         echo ""
     # Low-confidence patterns (case-insensitive) - exclude explicit ticket: requests
     elif echo "$PROMPT" | grep -qi 'ticket' && ! echo "$PROMPT" | grep -qi '^[[:space:]]*ticket[[:space:]]*:'; then

--- a/src/lib/hooks/builtin/MementoRoutingHook.ts
+++ b/src/lib/hooks/builtin/MementoRoutingHook.ts
@@ -284,9 +284,11 @@ if [ -n "$TICKET_REQUEST" ]; then
         echo "### Working with Tickets"
         echo ""
         echo "- Tickets are simple markdown files that serve as persistent workspaces"
+        echo "- **Read ticket files directly using the Read tool to understand their content**"
         echo "- Use your file editing tools to update ticket content directly"
         echo "- Tickets survive between sessions - use them to track progress and share context"
         echo "- When working on large tasks, create multiple tickets and delegate to sub-agents"
+        echo "- **Note: There are no built-in ticket commands to read content - use Read tool for file paths shown above**"
         echo ""
         
         # Output ticket content
@@ -329,9 +331,11 @@ if [ -z "$TICKET_REQUEST" ]; then
         echo "### Working with Tickets"
         echo ""
         echo "- Tickets are simple markdown files that serve as persistent workspaces"
+        echo "- **Read ticket files directly using the Read tool to understand their content**"
         echo "- Use your file editing tools to update ticket content directly"
         echo "- Tickets survive between sessions - use them to track progress and share context"
         echo "- When working on large tasks, create multiple tickets and delegate to sub-agents"
+        echo "- **Note: There are no built-in ticket commands to read content - use Read tool for file paths shown above**"
         echo ""
     # Low-confidence patterns (case-insensitive) - exclude explicit ticket: requests
     elif echo "$PROMPT" | grep -qi 'ticket' && ! echo "$PROMPT" | grep -qi '^[[:space:]]*ticket[[:space:]]*:'; then


### PR DESCRIPTION
Enhanced the memento-routing hook to explicitly encourage Claude to read ticket files directly using the Read tool. Added clear instructions that there are no built-in ticket commands to read content automatically.

## Changes
- Added explicit instruction to read ticket files using Read tool
- Clarified that no built-in ticket commands exist for reading content
- Updated both template source and installed version

Fixes #13

🤖 Generated with [Claude Code](https://claude.ai/code)