### PR TITLE
docs: revamp README for developer experience and clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,24 @@
 # Memento Protocol
 
-[![npm version](https://badge.fury.io/js/memento-protocol.svg)](https://badge.fury.io/js/memento-protocol) [![Stargazers over time](https://starchart.cc/git-on-my-level/memento-protocol.svg?variant=adaptive)](https://starchart.cc/git-on-my-level/memento-protocol)
+[![npm version](https://badge.fury.io/js/memento-protocol.svg)](https://badge.fury.io/js/memento-protocol)
 
 **Transform Claude Code from a basic AI assistant into a project-aware, context-intelligent development partner.**
 
 ## The Problem We Solve
 
 Claude Code starts to break down as your codebase grows. You find yourself:
-- Copy-pasting the same CLAUDE.md setup across projects
-- Watching Claude spam markdown files instead of organized task tracking  
-- Seeing Claude go in circles on complex fixes, repeating the same failed approaches
+- Re-adding the same best practices to CLAUDE.md across projects
+- Watching Claude spam markdown files instead of organized task tracking
+- Seeing Claude go in circles after context compacting, repeating the same failed approaches
+- Copy pasting the same roleplay prompts "Act as an engineer..." "Take on a QA role..." "Delegate to subagents..."
 
 ## Our Opinionated Solution
 
 Memento Protocol adds an **opinionated meta-framework layer** on top of Claude Code that enforces:
-- **Project context awareness** through intelligent routing and persistent state
+- **Project context awareness** through hooks that remind Claude about project tasks
 - **Structured task management** with tickets instead of scattered markdown files
-- **Specialized AI modes** (architect, engineer, reviewer) with fuzzy matching
-- **Automated workflows** triggered by your development patterns
+- **Built-in AI modes** (architect, engineer, reviewer, etc...) with roleplay best practices
+- **Automated workflows** so you can automate fuzzy but repetitive tasks (publish packages, security audit, etc...)
 
 ## Quick Start
 
@@ -49,6 +50,11 @@ npx memento-protocol init
 ## Contributing
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=git-on-my-level/memento-protocol&type=Timeline)](https://www.star-history.com/#git-on-my-level/memento-protocol&Timeline)
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,409 +1,54 @@
 # Memento Protocol
 
-[![npm version](https://badge.fury.io/js/memento-protocol.svg)](https://badge.fury.io/js/memento-protocol)
+[![npm version](https://badge.fury.io/js/memento-protocol.svg)](https://badge.fury.io/js/memento-protocol) [![Stargazers over time](https://starchart.cc/git-on-my-level/memento-protocol.svg?variant=adaptive)](https://starchart.cc/git-on-my-level/memento-protocol)
 
-A powerful enhancement framework for Claude Code that transforms projects with intelligent context management, custom commands, and specialized AI agents.
+**Transform Claude Code from a basic AI assistant into a project-aware, context-intelligent development partner.**
 
-## What is Memento Protocol?
+## The Problem We Solve
 
-Memento Protocol supercharges Claude Code with:
-- **AI Modes**: Switchable personalities with fuzzy matching (architect, engineer, reviewer)
-- **Claude Code Agents**: Specialized subagents for focused tasks (research, analysis, etc.)
-- **Custom Commands**: Project-specific slash commands (/mode, /ticket, /memento)
-- **Smart Hooks**: Automated workflows triggered by Claude Code events
-- **Tickets**: Persistent task tracking with intelligent context injection
-- **Workflows**: Reusable development procedures and patterns
-- **Acronym Expansion**: Auto-expansion of project terminology
+Claude Code starts to break down as your codebase grows. You find yourself:
+- Copy-pasting the same CLAUDE.md setup across projects
+- Watching Claude spam markdown files instead of organized task tracking  
+- Seeing Claude go in circles on complex fixes, repeating the same failed approaches
 
-All managed through an intelligent hook system that seamlessly integrates with Claude Code.
+## Our Opinionated Solution
 
-## This tool is for you if you answer yes to any of the following questions
-- Do you find yourself copy pasting between CLAUDE.md across projects all the time?
-- Does Claude Code start to break down as your codebase gets bigger?
-- Do you wish Claude would stop spamming markdown files and track its work in an opinionated and easy to clean up way?
-- For more complex fixes does Claude tend to go in circles, repeating the same methods over and over again?
+Memento Protocol adds an **opinionated meta-framework layer** on top of Claude Code that enforces:
+- **Project context awareness** through intelligent routing and persistent state
+- **Structured task management** with tickets instead of scattered markdown files
+- **Specialized AI modes** (architect, engineer, reviewer) with fuzzy matching
+- **Automated workflows** triggered by your development patterns
 
 ## Quick Start
 
-The easiest way to get started is by using `npx`, which allows you to run `memento-protocol` without a permanent installation.
-
-To initialize Memento Protocol in your project, run the interactive setup:
 ```bash
+# Initialize in your project
 npx memento-protocol init
+
+# Use enhanced Claude Code features
+/mode architect           # Switch AI personality  
+/ticket create "Add auth" # Create persistent task
+/memento                  # Project status overview
 ```
 
-You can also initialize with options, for example:
-```bash
-npx memento-protocol init --mode engineer --language typescript
-```
+## Key Features
 
-### Non-Interactive Setup
-
-For CI/CD or automated environments, use non-interactive mode:
-```bash
-npx memento-protocol init --non-interactive --modes architect,engineer --workflows review --hooks git-context-loader --default-mode architect
-```
-
-### Force Reinitialize (Dogfooding)
-
-For development or updating existing setups:
-```bash
-# Using yarn (no -- needed)
-yarn dev init --force --non-interactive
-
-# Using npm
-npm run dev init -- --force --non-interactive
-```
-
-### All Recommended Components
-
-To install all recommended components based on your project type:
-```bash
-npx memento-protocol init --all-recommended
-```
-
-This will create:
-- `.memento/`: Framework configuration and components
-- `.claude/`: Claude Code integration (agents, commands, settings)
-- Shell scripts for dynamic behavior
-- Hook configurations for automation
-
-**Note**: The `.memento/` directory should be added to `.gitignore` as it contains generated files.
-
-### Installation
-
-While `npx` is recommended for trying out Memento Protocol, you may prefer a global installation for convenience.
-
-```bash
-# Using npm
-npm install -g memento-protocol
-
-# Now you can use the 'memento' command directly
-memento init
-```
-
-For development, you can clone the repository:
-```bash
-# Using git
-git clone https://github.com/git-on-my-level/memento-protocol.git
-cd memento-protocol
-npm install
-npm link
-```
-
-## Basic Usage
-
-Once initialized, Claude Code will automatically:
-- Execute hooks for intelligent context routing and automation
-- Enable custom slash commands (/mode, /ticket, /memento)
-- Support fuzzy mode switching (e.g., 'apm' → 'autonomous-project-manager')
-- Load specialized agents for enhanced capabilities
-- Expand acronyms and inject relevant context
-- Track persistent task state through tickets
-
-## Commands
-
-### Core Commands
-
-#### `memento init`
-Initialize Memento Protocol in your project with interactive setup:
-```bash
-memento init [options]
-
-Options:
-  -f, --force                Force initialization
-  -n, --non-interactive      Non-interactive setup
-  -g, --gitignore           Add .memento/ to .gitignore
-  -m, --modes <modes>       Comma-separated list of modes
-  -w, --workflows <flows>   Comma-separated list of workflows  
-  -h, --hooks <hooks>       Comma-separated list of hooks
-  -a, --all-recommended     Install all recommended components
-  -d, --default-mode <mode> Set default mode
-```
-
-#### `memento update`
-Update components and regenerate CLAUDE.md:
-```bash
-memento update
-```
-
-#### `memento` (no arguments)
-Smart update - initializes if needed, otherwise updates:
-```bash
-memento
-```
-
-### Component Management
-
-#### `memento add <type> <name>`
-Add modes, workflows, or agents:
-```bash
-memento add mode architect              # Add AI mode
-memento add workflow review             # Add workflow
-memento add agent claude-code-research  # Add Claude Code agent
-```
-
-#### `memento list`
-List available and installed components:
-```bash
-memento list              # Show all available
-memento list --installed  # Show only installed
-```
-
-### Hook Management
-
-#### `memento hook`
-Manage Claude Code hooks:
-```bash
-memento hook list                    # List all configured hooks
-memento hook add acronym-expander    # Add hook from template
-memento hook enable <id>             # Enable a hook
-memento hook disable <id>            # Disable a hook
-memento hook remove <id>             # Remove a hook
-memento hook templates               # List available templates
-```
-
-### Ticket Management
-
-#### `memento ticket`
-Manage persistent task tickets:
-```bash
-memento ticket create "Add authentication"  # Create new ticket
-memento ticket list                         # List all tickets
-memento ticket list --status in-progress    # Filter by status
-memento ticket start <id>                   # Move to in-progress
-memento ticket resolve <id>                 # Mark as done
-memento ticket delete <id>                  # Delete ticket
-```
-
-### Custom Commands Management
-
-#### `memento command`
-Manage Claude Code custom commands:
-```bash
-memento command install                     # Install custom commands
-memento command status                      # Check installation status
-memento command cleanup                     # Remove all commands
-```
-
-### Acronym Management
-
-#### `memento acronym`
-Manage project-specific acronyms:
-```bash
-memento acronym add api "Application Programming Interface"
-memento acronym add ddd "Domain Driven Design"
-memento acronym list                        # List all acronyms
-memento acronym remove api                  # Remove an acronym
-memento acronym clear                       # Clear all acronyms
-```
-
-### Configuration
-
-#### `memento config`
-Manage configuration:
-```bash
-memento config get defaultMode              # Get a setting
-memento config set defaultMode engineer     # Set a setting
-memento config list                         # List all settings
-```
-
-## Claude Code Integration
-
-### Using Modes
-Switch AI personalities with fuzzy matching:
-```bash
-# Using custom command
-/mode architect    # Exact match
-/mode eng         # Fuzzy match → engineer
-/mode apm         # Acronym → autonomous-project-manager
-
-# Or in prompts
-mode: architect   # System design focus
-mode: engineer    # Implementation focus
-```
-
-### Using Workflows
-Execute predefined procedures:
-```
-workflow: review    # Comprehensive code review
-workflow: summarize # Compress context
-```
-
-### Using Tickets
-Track persistent tasks:
-```
-ticket: create "Add user authentication"
-ticket: start auth-feature
-ticket: done
-```
-
-### Using Custom Commands
-Direct access to Memento features in Claude Code:
-```bash
-# Mode management with fuzzy matching
-/mode                    # List available modes
-/mode architect         # Switch to architect mode
-/mode eng              # Fuzzy match to engineer
-
-# Ticket management
-/ticket                 # List all tickets
-/ticket my-feature      # Load ticket context
-
-# Project status
-/memento               # Show project overview
-```
-
-### Using Subagents
-Leverage specialized AI agents:
-```
-# Install the Claude Code research agent
-memento add agent claude-code-research
-
-# Agent will be available for Claude to invoke automatically
-# when you need help with Claude Code features
-```
-
-### Acronym Expansion
-Configured acronyms are automatically expanded:
-```
-User: "Let's implement the API using DDD principles"
-Claude sees: 
-## Acronym Glossary
-- **API**: Application Programming Interface  
-- **DDD**: Domain Driven Design
-
----
-
-Let's implement the API using DDD principles
-```
-
-## Hook System
-
-Memento Protocol includes a powerful hook system for automation:
-
-### Built-in Hooks
-- **memento-routing**: Intelligent mode/workflow/ticket routing with fuzzy matching
-- **git-context-loader**: Auto-loads git status and project structure
-- **project-overview**: Provides project context at session start
-- **acronym-expander**: Expands project-specific terminology
-
-### Custom Hooks
-Create custom automation for:
-- Pre/post tool usage (formatting, linting, testing)
-- Prompt filtering and modification
-- Session initialization
-- Command validation
-
-See [docs/HOOKS_GUIDE.md](docs/HOOKS_GUIDE.md) for detailed documentation.
-
-## Project Structure
-
-```
-.
-├── CLAUDE.md          # Main router file for Claude Code
-├── .claude/           # Claude Code specific directory
-│   ├── agents/        # Installed subagents
-│   └── commands/      # Custom slash commands
-├── .memento/          # Framework directory (add to .gitignore)
-│   ├── modes/         # Installed AI modes
-│   ├── workflows/     # Installed workflows
-│   ├── tickets/       # Task tickets (next/in-progress/done)
-│   ├── hooks/         # Hook definitions and scripts
-│   ├── acronyms.json  # Acronym definitions
-│   └── config.json    # Project configuration
-```
+- **AI Modes**: Switchable personalities (architect, engineer, reviewer) with smart fuzzy matching
+- **Persistent Tickets**: Task tracking that survives Claude sessions with context injection
+- **Smart Hooks**: Automated workflows triggered by Claude Code events (git context, acronym expansion)
+- **Custom Commands**: Project-specific slash commands (/mode, /ticket, /memento)
+- **Claude Code Agents**: Specialized subagents for research, analysis, and domain-specific tasks
 
 ## Documentation
 
-- [Component Guide](docs/COMPONENT_GUIDE.md) - Creating custom modes and workflows
-- [Hooks Guide](docs/HOOKS_GUIDE.md) - Complete hook system documentation
+- [Quick Start Guide](docs/QUICKSTART.md) - Get up and running in 5 minutes
+- [Component Guide](docs/COMPONENT_GUIDE.md) - Creating custom modes and workflows  
+- [Hooks Guide](docs/HOOKS_GUIDE.md) - Automation and integration patterns
 - [API Reference](docs/API.md) - Programmatic usage
-- [Contributing Guide](CONTRIBUTING.md) - How to contribute
-
-## Examples
-
-### Quick Project Setup
-```bash
-# Initialize with recommended components
-npx memento-protocol init --all-recommended
-
-# Add project acronyms
-memento acronym add k8s "Kubernetes"
-memento acronym add ci/cd "Continuous Integration/Continuous Deployment"
-
-# Create initial tickets
-memento ticket create "Setup testing framework"
-memento ticket create "Add authentication"
-```
-
-### Custom Hook Example
-```bash
-# Add auto-formatting hook
-cat > .memento/hooks/definitions/auto-format.json << 'EOF'
-{
-  "version": "1.0.0",
-  "hooks": [{
-    "id": "auto-format",
-    "name": "Auto Formatter",
-    "event": "PostToolUse",
-    "enabled": true,
-    "matcher": {
-      "type": "tool",
-      "pattern": "Write,Edit,MultiEdit"
-    },
-    "command": "npm run format -- $HOOK_TOOL_ARG_FILE_PATH",
-    "continueOnError": true
-  }]
-}
-EOF
-
-# Regenerate hooks
-memento
-```
-
-### Custom Commands in Action
-```bash
-# Initialize Memento Protocol
-npx memento-protocol init
-
-# Custom commands are now available in Claude Code:
-
-# Mode switching with fuzzy matching
-/mode                  # Shows: architect, engineer, reviewer, etc.
-/mode eng             # Switches to engineer mode
-/mode apm             # Switches to autonomous-project-manager
-
-# Ticket management
-/ticket               # Lists all tickets
-/ticket auth-feature  # Loads specific ticket context
-
-# Project status
-/memento             # Shows modes, workflows, tickets, configuration
-```
-
-### Subagent Example
-```bash
-# Add the Claude Code research agent
-memento add agent claude-code-research
-
-# The agent is now available for Claude to invoke
-# when you ask about Claude Code features:
-# "What are the latest features in Claude Code?"
-# "How do I use MCP servers with Claude?"
-```
 
 ## Contributing
 
-We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
-
-## What's New in v0.7.0
-
-- **Claude Code Agents**: Full subagent support with .claude/agents/ integration
-- **Fuzzy Mode Matching**: Smart mode switching with acronym support
-- **Enhanced Commands**: Improved custom command system with proper permissions
-- **Better Hooks**: Modular hook architecture with focused responsibilities
-- **GitHub Integration**: Automated CI/CD workflows for Claude Code projects
+We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 

--- a/docs/COMPONENT_GUIDE.md
+++ b/docs/COMPONENT_GUIDE.md
@@ -1,201 +1,248 @@
 # Component Creation Guide
 
-This guide helps LLMs and developers create custom components for Memento Protocol.
+This guide helps LLMs and developers create effective components for Memento Protocol. Focus on what actually helps agents execute tasks successfully.
 
 ## Component Types
 
-### 1. Modes (Personality/Behavior)
+### 1. Modes (Agent Personalities)
 
 Location: `.memento/modes/<name>.md`
 
-**Standardized Section Structure** (must be in this order):
-1. `## Behavioral Guidelines` - How the mode communicates and makes decisions
-2. `## Core Responsibilities` - Primary duties and areas of focus
-3. `## Best Practices` - Recommended approaches and methods
-4. `## Mode Switching Triggers` - When to switch to other modes
-5. `## Done When` - Clear completion criteria
-6. `## Example Commands` - Natural language invocations and use cases
+Modes define how agents think and behave. The most effective modes focus on **actionable behavioral guidelines** rather than abstract concepts.
 
-Structure:
+#### Effective Mode Structure
+
 ```markdown
 # [Mode Name] Mode
 
-[One paragraph description of the mode's purpose and focus]
+[One clear sentence describing the agent's identity and primary focus]
 
 ## Behavioral Guidelines
 
-### Communication Style
-- [How this mode communicates]
-- [Tone and formality level]
-- [Key communication principles]
+[2-4 specific, actionable behavioral instructions that shape how the agent makes decisions and communicates]
 
-### Decision Making
-- [How this mode makes decisions]
-- [Prioritization approach]
-- [Trade-off considerations]
+## Example Process
 
-## Core Responsibilities
+[Optional: A flexible framework showing typical phases of work, not rigid steps]
 
-1. **[Responsibility Area]**
-   - [Specific duties]
-   - [Key activities]
+### Phase 1: [Name]
+- [Key activities and mindset]
 
-2. **[Responsibility Area]**
-   - [Specific duties]
-   - [Key activities]
+### Phase 2: [Name]  
+- [Key activities and mindset]
 
-## Best Practices
-
-1. **[Practice Category]**
-   - [Specific practices]
-   - [Guidelines]
-
-2. **[Practice Category]**
-   - [Specific practices]
-   - [Guidelines]
-
-## Mode Switching Triggers
-
-Switch to:
-- **[Mode]** when [condition]
-- **[Mode]** when [condition]
-
-## Done When
-
-- [Clear completion criterion]
-- [Measurable outcome]
-- [Success indicator]
-
-## Example Commands
-
-### Natural Language Invocations
-- [3-4 examples of how users might naturally invoke this mode]
-- [Include variations in phrasing]
-
-### Common Use Cases
-- [Specific command examples with typical tasks]
-- [Show the command format and expected outcome]
-
-### [Optional: Implementation/Review/Planning Examples]
-[Code snippets or structured examples specific to the mode]
+[Additional sections as needed for the specific mode]
 ```
 
-### 2. Workflows (Procedures)
+#### What Makes Modes Effective
+
+**✅ Good Behavioral Guidelines:**
+- "Be pragmatic, focus on clear, easy to understand code over elegant and over-engineered code"
+- "Save your own context, delegate work to sub-agents whenever possible"
+- "Prioritize critical issues (bugs, security vulnerabilities) over stylistic preferences"
+
+**❌ Avoid These:**
+- Vague personality descriptions ("be helpful and friendly")
+- Mode switching triggers (agents can't switch themselves)
+- Rigid step-by-step procedures (use Example Process for flexibility)
+- Abstract principles without actionable guidance
+
+#### Examples of Effective Patterns
+
+- **Identity Statement**: "You are now operating in Engineer mode. Your focus is on crafting high-quality code."
+- **Decision Framework**: "If requirements are clear, take a TDD approach; if not, implement then test"
+- **Resource Management**: "Delegate to sub-agents, bias towards cost savings"
+- **Quality Standards**: "Don't write brittle tests. Avoid asserting things likely to change"
+
+### 2. Workflows (Reusable Procedures)
 
 Location: `.memento/workflows/<name>.md`
 
-Structure:
-```markdown
-# Workflow: [Name]
+Workflows provide structured approaches to common tasks. The best workflows balance structure with flexibility.
 
-[Brief description of what this workflow accomplishes]
+#### Effective Workflow Structure
+
+```markdown
+# [Workflow Name]
+
+[Brief description of what this accomplishes and when to use it]
 
 ## Prerequisites
-- [Any required setup or context]
-- [Dependencies or requirements]
+- [What agents need before starting]
+- [Required context or setup]
 
-## Example Commands
-### Natural Language Invocations
-- [3-4 examples of how users might naturally execute this workflow]
-- [Include parameter variations]
-
-### Common Use Cases
-- [Specific execution examples with parameters]
-- [Show different parameter combinations and their effects]
-
-## Steps
-1. **[Step Name]**: [Detailed description]
-   - [Sub-steps if needed]
-   - [Expected outcomes]
-
-2. **[Step Name]**: [Detailed description]
-   - [Sub-steps if needed]
-   - [Expected outcomes]
+## Inputs
+- **parameter**: Description of expected input
+- **parameter**: Description with example formats
 
 ## Outputs
 - [What this workflow produces]
-- [Artifacts or deliverables]
+- [Where results are stored]
 
-## Next Steps
-- [Typical follow-up actions]
-- [Related workflows]
+## Example Commands
+
+### Natural Language Invocations
+- "[4-5 examples of how users naturally request this workflow]"
+- "[Include parameter variations]"
+
+## Workflow Steps
+
+### 1. [Phase Name]
+[Clear description of this phase's purpose]
+
+1. **[Specific Action]**
+   - [Concrete steps]
+   - [Expected outcomes]
+
+2. **[Specific Action]**
+   - [Concrete steps]
+   - [Expected outcomes]
+
+### 2. [Phase Name]
+[Continue pattern...]
+
+## Best Practices
+- [Workflow-specific guidance]
+- [Common pitfalls to avoid]
 ```
+
+#### What Makes Workflows Effective
+
+**✅ Good Workflow Characteristics:**
+- Clear inputs and outputs agents can work with
+- Natural language invocation examples that actually work
+- Flexible phases rather than rigid sequences
+- Specific action items with expected outcomes
+- Integration with modes and tools
+
+**❌ Avoid These:**
+- Theoretical procedures without concrete steps
+- Overly rigid sequences that don't adapt to reality
+- Vague action items without clear outcomes
+- No connection to how agents actually work
 
 ### 3. Language Overrides
 
 Location: `.memento/languages/<language>/overrides.md`
 
-Structure:
+Language overrides help agents work effectively with specific technologies and codebases.
+
+#### Structure
+
 ```markdown
 # Language: [Language Name]
 
-## Conventions
-- [Language-specific coding standards]
-- [Naming conventions]
-- [File organization]
+## Behavioral Adaptations
+- [How agents should modify their approach for this language]
+- [Language-specific mindset and priorities]
+
+## Code Conventions
+- [Specific patterns and styles to follow]
+- [Naming conventions and organization]
 
 ## Best Practices
-- [Language-specific patterns]
-- [Performance considerations]
-- [Security guidelines]
+- [Language-specific quality standards]
+- [Performance and security considerations]
 
 ## Common Patterns
 ### [Pattern Name]
 ```[language]
-// Example code
+// Concrete example showing the pattern
 ```
 
-## Testing Approach
-- [Preferred testing framework]
-- [Test organization]
-- [Coverage expectations]
-
-## Build & Deploy
-- [Build tools and processes]
-- [Deployment considerations]
+## Testing & Verification
+- [Preferred testing approaches]
+- [How to validate code quality]
 ```
 
-## Metadata Files
+## Component Creation Best Practices
 
-Each component directory should have a `metadata.json`:
+### 1. Write for Agent Execution Context
 
-```json
-{
-  "components": {
-    "component-name": {
-      "description": "Brief description",
-      "version": "1.0.0",
-      "tags": ["tag1", "tag2"],
-      "author": "optional-author"
-    }
-  }
-}
+Remember: agents only see your component content AFTER they've been invoked. Write for that context.
+
+**✅ Agent-Focused Writing:**
+- "You are now operating in [Mode] mode"
+- "Your focus is on [specific capability]"
+- "Follow this approach when [specific situation]"
+
+**❌ User-Focused Writing:**
+- "This mode helps with [general description]"
+- "Switch to this mode when [trigger condition]"
+- "Users can invoke this by [method]"
+
+### 2. Provide Actionable Guidance
+
+Agents need specific, executable instructions, not abstract principles.
+
+**✅ Actionable:**
+- "Use TDD if requirements are clear, implement-then-test if they're unclear"
+- "Bias towards cost savings when choosing sub-agent models"
+- "Focus on critical issues before stylistic preferences"
+
+**❌ Abstract:**
+- "Write good code"
+- "Be thorough"
+- "Consider best practices"
+
+### 3. Balance Structure with Flexibility
+
+Provide frameworks, not rigid scripts. Agents need to adapt to real situations.
+
+**✅ Flexible Framework:**
+```markdown
+## Example Process
+This is an example process. Be flexible and use good judgment based on the actual task.
+
+### Phase 1: Planning
+- Identify core requirements
+- Gather context in parallel
+
+### Phase 2: Implementation
+- Spawn sub-agents as needed
 ```
 
-## Best Practices
+**❌ Rigid Script:**
+```markdown
+## Steps
+1. Always start by reading the requirements
+2. Then analyze the codebase
+3. Then create a plan
+4. Then implement
+```
 
-1. **Be Specific**: Components should have a clear, focused purpose
-2. **Be Concise**: Avoid unnecessary verbosity
-3. **Be Practical**: Include real-world examples
-4. **Be Consistent**: Follow the established format
-5. **Be Helpful**: Anticipate common questions
+### 4. Include Real Examples
+
+Show agents exactly what effective execution looks like.
+
+**Examples:**
+- Code snippets for language overrides
+- Natural language commands for workflows
+- Decision-making scenarios for modes
 
 ## Testing Your Components
 
 After creating a component:
 
-1. Install it: `memento add [type] [name]`
-2. Regenerate CLAUDE.md: `memento init --update`
-3. Test with Claude Code to ensure it works as expected
+1. **Install it**: `memento add [type] [name]`
+2. **Test with real scenarios**: Use the component in actual development tasks
+3. **Observe agent behavior**: Does the component actually improve how agents work?
+4. **Iterate based on results**: Refine based on what works in practice
 
-## Sharing Components
+## Quality Indicators
 
-To share your components:
+**Effective Components:**
+- Agents make better decisions when using them
+- Clear improvement in task completion quality
+- Natural integration with agent workflows
+- Reduced need for clarification or iteration
 
-1. Create a GitHub repository
-2. Structure it like the official template repo
-3. Users can then configure it as their template source
+**Ineffective Components:**
+- Agents ignore or misinterpret guidance
+- No observable improvement in outcomes
+- Conflicts with natural agent behavior
+- Requires extensive explanation to be useful
 
 ## Examples
 
-See the `templates/` directory for reference implementations of all component types.
+See the `.memento/modes/` and `.memento/workflows/` directories for reference implementations that follow these patterns.


### PR DESCRIPTION
Addresses issue #22 by transforming the README from verbose documentation into a focused developer experience:

- Reduced from 410 to 55 lines (87% reduction)
- Added clear "Problem We Solve" section highlighting Claude Code limitations
- Explicitly positioned as opinionated meta-framework layer
- Added stargazers chart for social proof
- Restructured with developer-first messaging

Generated with [Claude Code](https://claude.ai/code)